### PR TITLE
fix: fix the typo in the command name

### DIFF
--- a/plugin/lspfuzzy.vim
+++ b/plugin/lspfuzzy.vim
@@ -17,7 +17,7 @@ endif
 if !get(g:, 'lspfuzzy_no_default', 0)
   command! -nargs=? -bang FzfLspDocumentSymbol  call fzf#lsp#document_symbol(<bang>0)
   command! -nargs=? -bang FzfLspWorkspaceSymbol call fzf#lsp#workspace_symbol(<q-args>,<bang>0)
-  command! -nargs=? -bang FzfLspDefintion       call fzf#lsp#definition(<bang>0)
+  command! -nargs=? -bang FzfLspDefinition      call fzf#lsp#definition(<bang>0)
   command! -nargs=? -bang FzfLspDeclaration     call fzf#lsp#declaration(<bang>0)
   command! -nargs=? -bang FzfLspTypeDefinition  call fzf#lsp#type_definition(<bang>0)
   command! -nargs=? -bang FzfLspImplementation  call fzf#lsp#implementation(<bang>0)


### PR DESCRIPTION
I found a typo in the command name. I fixed it.